### PR TITLE
ci: remove obsolete loginservice configmap

### DIFF
--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -6,8 +6,6 @@ metadata:
   labels:
     team: min-side
 spec:
-  envFrom:
-    - configmap: loginservice-idporten
   image: {{version}}
   port: 8080
   liveness:
@@ -43,5 +41,3 @@ spec:
       value: "true"
     - name: UTKAST_TOPIC_NAME
       value: min-side.aapen-utkast-v1
-
-

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
   envFrom:
     - secret: tms-event-test-producer-secrets
-    - configmap: loginservice-idporten
   image: {{version}}
   port: 8080
   liveness:
@@ -36,4 +35,3 @@ spec:
       memory: 64Mi
   kafka:
     pool: nav-prod
-


### PR DESCRIPTION
Loginservice har ikke eksistert i noen år nå. ConfigMapet skal nå fjernes. Fortsatt referanse til det vil ganske snart forhindre videre deploy.